### PR TITLE
Fix shell script syntax errors and install bus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ CMD ["/sbin/my_init"]
 # Install Plex
 RUN apt-get -q update && \
 VERSION=$(curl https://raw.githubusercontent.com/linuxserver/misc-files/master/plex-version/public) && \
-apt-get install -qy gdebi-core wget && \
+apt-get install -qy dbus gdebi-core wget && \
 wget -P /tmp "http://downloads.plexapp.com/plex-media-server/$VERSION/plexmediaserver_${VERSION}_amd64.deb" && \
 gdebi -n /tmp/plexmediaserver_${VERSION}_amd64.deb && \
 rm -f /tmp/plexmediaserver_${VERSION}_amd64.deb && \

--- a/init/20_update_plex.sh
+++ b/init/20_update_plex.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export DEBIAN_FRONTEND=noninteractive
 INSTALLED=`dpkg-query -W -f='${Version}' plexmediaserver`
-if [ "$PLEXPASS" -eq "1" ]; then
+if [ "$PLEXPASS" == "1" ]; then
 	VERSION=$(curl https://raw.githubusercontent.com/linuxserver/misc-files/master/plex-version/plexpass)
 else
 	VERSION=$(curl https://raw.githubusercontent.com/linuxserver/misc-files/master/plex-version/public)

--- a/init/90_uid_gid_fix.sh
+++ b/init/90_uid_gid_fix.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ ! "$(id -u abc)" -eq "$PUID" ]; then usermod -u "$PUID" abc ; fi
-if [ ! "$(id -g abc)" -eq "$PGID" ]; then groupmod -o -g  "$PGID" abc ; fi
+if [ "$(id -u abc)" != "$PUID" ]; then usermod -u "$PUID" abc ; fi
+if [ "$(id -g abc)" != "$PGID" ]; then groupmod -o -g  "$PGID" abc ; fi
 
 echo "
 -----------------------------------


### PR DESCRIPTION
The string comparisons in the init script are incorrect.
dbus isn't fully installed, for example the "messagebus" user and group were not present and the "/bin/dbus-uuidgen" executable wasn't there.
